### PR TITLE
Workaround render issues in hotbar, when Immediately Fast is being used

### DIFF
--- a/src/main/java/dev/crec/mapinslot/ImmediatelyFastUtil.java
+++ b/src/main/java/dev/crec/mapinslot/ImmediatelyFastUtil.java
@@ -1,0 +1,89 @@
+package dev.crec.mapinslot;
+
+import net.fabricmc.loader.api.FabricLoader;
+import org.jetbrains.annotations.Nullable;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+public class ImmediatelyFastUtil {
+    private static @Nullable Boolean cachedIsModAvailable;
+
+    public static class ImmediatelyFastBatchingAccessWrapper {
+        private final Method beginHudBatchingMethod, endHudBatchingMethod, isHudBatching;
+        private final Object batchingAccessInstance;
+
+        public ImmediatelyFastBatchingAccessWrapper(Object batchingAccessInstance) throws ClassNotFoundException, NoSuchMethodException {
+            this.batchingAccessInstance = batchingAccessInstance;
+            if(batchingAccessInstance == null)
+                throw new IllegalArgumentException("ImmediatelyFastBatchingAccessWrapper: Instance is null!");
+            this.beginHudBatchingMethod = getBatchingAccessClass().getDeclaredMethod("beginHudBatching");
+            this.endHudBatchingMethod = getBatchingAccessClass().getDeclaredMethod("endHudBatching");
+            this.isHudBatching = getBatchingAccessClass().getDeclaredMethod("isHudBatching");
+        }
+
+        public void beginHudBatching() throws InvocationTargetException, IllegalAccessException {
+            beginHudBatchingMethod.invoke(batchingAccessInstance);
+        }
+
+        public void endHudBatching() throws InvocationTargetException, IllegalAccessException {
+            endHudBatchingMethod.invoke(batchingAccessInstance);
+        }
+
+        public boolean isHudBatching() throws InvocationTargetException, IllegalAccessException {
+            return (boolean) isHudBatching.invoke(batchingAccessInstance);
+        }
+    }
+
+    public static boolean isModAvailable() {
+        if(cachedIsModAvailable == null) {
+            cachedIsModAvailable = FabricLoader.getInstance().isModLoaded("immediatelyfast");
+            if(cachedIsModAvailable)
+                MapInSlot.getLogger().info("Detected the Mod \"Immediately Fast\". Will use workaround to prevent render glitches in hotbar.");
+        }
+        return cachedIsModAvailable;
+    }
+
+    private static Class<?> getApiClass() throws ClassNotFoundException {
+        return Class.forName("net.raphimc.immediatelyfastapi.ImmediatelyFastApi");
+    }
+
+    private static Class<?> getApiAccessClass() throws ClassNotFoundException {
+        return Class.forName("net.raphimc.immediatelyfastapi.ApiAccess");
+    }
+
+    private static Class<?> getBatchingAccessClass() throws ClassNotFoundException {
+        return Class.forName("net.raphimc.immediatelyfastapi.BatchingAccess");
+    }
+
+    public static Object getApiAccessInstance() {
+        try {
+            Method getApiImplMethod = getApiClass().getDeclaredMethod("getApiImpl");
+            return getApiImplMethod.invoke(null);
+        }catch (Exception ex) {
+            MapInSlot.getLogger().error("Failed to get ApiAccess instance.", ex);
+            return null;
+        }
+    }
+
+    public static Object getBatchingAccessInstance(Object apiAccessInstance) {
+        try {
+            Method getBatchingMethod = getApiAccessClass().getDeclaredMethod("getBatching");
+            return getBatchingMethod.invoke(apiAccessInstance);
+        }catch (Exception ex) {
+            MapInSlot.getLogger().error("Failed to get ApiAccess instance.", ex);
+            return null;
+        }
+    }
+
+    public static @Nullable ImmediatelyFastBatchingAccessWrapper getBatchingAccessWrapper() {
+        try {
+            Object batchingAccessInstance = getBatchingAccessInstance(getApiAccessInstance());
+            return new ImmediatelyFastBatchingAccessWrapper(batchingAccessInstance);
+        }catch (Exception ex) {
+            MapInSlot.getLogger().error("Failed to get ApiAccess instance.", ex);
+            return null;
+        }
+    }
+
+}

--- a/src/main/java/dev/crec/mapinslot/MapInSlot.java
+++ b/src/main/java/dev/crec/mapinslot/MapInSlot.java
@@ -1,0 +1,17 @@
+package dev.crec.mapinslot;
+
+import org.jetbrains.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class MapInSlot {
+
+    private static @Nullable Logger LOGGER = null;
+
+    public static Logger getLogger() {
+        if(LOGGER == null)
+            LOGGER = LoggerFactory.getLogger("mapinslot");
+        return LOGGER;
+    }
+
+}

--- a/src/main/java/dev/crec/mapinslot/mixin/ItemRendererMixin.java
+++ b/src/main/java/dev/crec/mapinslot/mixin/ItemRendererMixin.java
@@ -34,7 +34,7 @@ public abstract class ItemRendererMixin {
 
     @Inject(
             method = "renderItemDecorations(Lnet/minecraft/client/gui/Font;Lnet/minecraft/world/item/ItemStack;IILjava/lang/String;)V",
-            at = @At(value = "TAIL")
+            at = @At(value = "HEAD")
     )
     private void drawMap(Font font, ItemStack stack, int i, int j, String string, CallbackInfo ci) {
         if (!stack.is(Items.FILLED_MAP)) return;

--- a/src/main/java/dev/crec/mapinslot/mixin/ItemRendererMixin.java
+++ b/src/main/java/dev/crec/mapinslot/mixin/ItemRendererMixin.java
@@ -1,6 +1,8 @@
 package dev.crec.mapinslot.mixin;
 
 import com.mojang.blaze3d.vertex.PoseStack;
+import dev.crec.mapinslot.ImmediatelyFastUtil;
+import dev.crec.mapinslot.MapInSlot;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.Font;
 import net.minecraft.client.gui.GuiGraphics;
@@ -9,9 +11,11 @@ import net.minecraft.core.component.DataComponents;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
 import net.minecraft.world.item.MapItem;
+import org.jetbrains.annotations.Nullable;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
@@ -32,12 +36,23 @@ public abstract class ItemRendererMixin {
     @Shadow
     public abstract void flush();
 
+    @Unique @Nullable ImmediatelyFastUtil.ImmediatelyFastBatchingAccessWrapper ifWrapper = ImmediatelyFastUtil.isModAvailable() ? ImmediatelyFastUtil.getBatchingAccessWrapper() : null;
+
     @Inject(
             method = "renderItemDecorations(Lnet/minecraft/client/gui/Font;Lnet/minecraft/world/item/ItemStack;IILjava/lang/String;)V",
-            at = @At(value = "HEAD")
+            at = @At(value = "TAIL")
     )
     private void drawMap(Font font, ItemStack stack, int i, int j, String string, CallbackInfo ci) {
         if (!stack.is(Items.FILLED_MAP)) return;
+
+        final boolean doInterruptIfHudBatching;
+        try {
+            doInterruptIfHudBatching = ifWrapper != null && ifWrapper.isHudBatching();
+            if (doInterruptIfHudBatching) ifWrapper.endHudBatching();
+        }catch (Exception ex) {
+            MapInSlot.getLogger().error("Failed to interact with Mod \"Immediately Fast\". The API likely changed and is not what MapInSlot expects, anymore!");
+            return;
+        }
 
         var mapId = stack.get(DataComponents.MAP_ID);
         var savedData = MapItem.getSavedData(mapId, this.minecraft.level);
@@ -53,6 +68,11 @@ public abstract class ItemRendererMixin {
                 .render(this.pose(), this.bufferSource(), mapId, savedData, true, 15728880);
         this.flush();
         this.pose().popPose();
+
+        try {
+            if (doInterruptIfHudBatching) ifWrapper.beginHudBatching();
+        }catch (Exception ignored) {}
+
     }
 
 }


### PR DESCRIPTION
Hi,

I recently noticed, that when I held a map with a count > 1 in my hotbar, it would sometimes refuse to render or starting to render weirdly, at the location, the item counter would go.

![screenshot0005-46](https://github.com/Crec0/map-in-slot/assets/117233381/4f78fbd4-3b84-4a0d-838a-e96a8389ed50)

It seemed in general to fail, when I held more than 2 maps in my hotbar. Often just not rendering at all there.

I tried to fix it with changing the Mixins Inject-Location from TAIL to HEAD, but that just seemed to change the behavior a bit.

I then tried a wild guess, that Immediately Fast was causing it and was right. Without Immediately Fast, rendering was fine.

I'm not entirely sure if this Workaround is the best way, or if, perhaps, this is an issue more suited towards Immediately Fast.

But this fixes that issue, by essentially interrupting Immediately Fast's batching, each time a Mapart texture is rendered.